### PR TITLE
add stack setup to linux install

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ pip3 install -r requirements.txt
 curl -sSL https://get.haskellstack.org/ | sh
 git clone https://github.com/gibiansky/IHaskell
 cd IHaskell
+stack setup
 stack install gtk2hs-buildtools
 stack install --fast
 ihaskell install --stack


### PR DESCRIPTION
Very minor.  I had to explicitly run `stack setup` when doing a fresh install.  Perhaps some newcomers might stumble, or perhaps this change is just not needed.